### PR TITLE
resolve some feature and deprecation warnings from the compiler

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -34,7 +34,11 @@ object ApplicationBuild extends Build {
     settings = BuildSettings.buildSettings ++ Seq(
       //logLevel := Level.Debug,
       //ivyLoggingLevel := UpdateLogging.Full,
-      //scalacOptions ++= Seq("-Xlog-implicits"),
+      scalacOptions ++= Seq(
+        //"-Xlog-implicits",
+        //"-deprecation",
+        //"-feature"
+      ),
       fork in Test := true,
       //parallelExecution in Test := false,
       //javaOptions in test += "-Xmx512M -Xmx512m -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1024M",

--- a/src/main/scala/DatomicData.scala
+++ b/src/main/scala/DatomicData.scala
@@ -285,10 +285,10 @@ class DEntity(val entity: datomic.Entity) extends DatomicData {
   def toMap: Map[Keyword, DatomicData] = {
     import scala.collection.JavaConverters._
 
-    entity.keySet.asScala.view map { x: Any =>
+    entity.keySet.asScala.view.map{ x: Any =>
       val key = x.asInstanceOf[clojure.lang.Keyword]
       (Keyword(key) -> Datomic.toDatomicData(entity.get(key)))
-    } toMap
+    }.toMap
   }
 
   /* extension with attributes */

--- a/src/main/scala/DatomicFact.scala
+++ b/src/main/scala/DatomicFact.scala
@@ -16,6 +16,7 @@
 
 package datomisca
 
+import scala.language.reflectiveCalls
 import language.experimental.macros
 
 import dmacros._

--- a/src/main/scala/DatomicMapping.scala
+++ b/src/main/scala/DatomicMapping.scala
@@ -16,6 +16,8 @@
 
 package datomisca
 
+import scala.language.implicitConversions
+
 import scala.util.{Try, Success, Failure}
 
 case class Ref[T](ref: T, id: DId) {

--- a/src/main/scala/DatomicOps.scala
+++ b/src/main/scala/DatomicOps.scala
@@ -16,6 +16,8 @@
 
 package datomisca
 
+import scala.language.reflectiveCalls
+
 import scala.collection.JavaConverters._
 
 trait Operation extends Nativeable

--- a/src/main/scala/DatomicParser.scala
+++ b/src/main/scala/DatomicParser.scala
@@ -16,6 +16,8 @@
 
 package datomisca
 
+import scala.language.reflectiveCalls
+
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.combinator.RegexParsers
 import scala.util.parsing.input.{Positional, Reader}

--- a/src/main/scala/DatomicQuery.scala
+++ b/src/main/scala/DatomicQuery.scala
@@ -16,10 +16,11 @@
 
 package datomisca
 
+import scala.language.higherKinds
+import language.experimental.macros
+
 import scala.util.{Try, Success, Failure}
 import scala.util.parsing.input.Positional
-
-import language.experimental.macros
 
 import dmacros._
 

--- a/src/main/scala/DatomicSchema.scala
+++ b/src/main/scala/DatomicSchema.scala
@@ -16,6 +16,8 @@
 
 package datomisca
 
+import scala.language.reflectiveCalls
+
 trait SchemaType[DD <: DatomicData] {
   def keyword: Keyword
 }

--- a/src/main/scala/DatomicTerms.scala
+++ b/src/main/scala/DatomicTerms.scala
@@ -16,6 +16,8 @@
 
 package datomisca
 
+import scala.language.reflectiveCalls
+
 import scala.util.parsing.input.Positional
 
 

--- a/src/main/scala/Utils.scala
+++ b/src/main/scala/Utils.scala
@@ -16,6 +16,9 @@
 
 package datomisca
 
+import scala.language.higherKinds
+import scala.language.implicitConversions
+
 import datomic.ListenableFuture
 
 import scala.concurrent.{Future, Promise, ExecutionContext}

--- a/src/test/scala/DatomicBootstrap.scala
+++ b/src/test/scala/DatomicBootstrap.scala
@@ -1,4 +1,7 @@
 import datomisca._
+
+import scala.language.reflectiveCalls
+
 import scala.concurrent._
 import scala.concurrent.util._
 import scala.concurrent.duration._

--- a/src/test/scala/DatomicDemoSpec.scala
+++ b/src/test/scala/DatomicDemoSpec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith

--- a/src/test/scala/DatomicMapping2Spec.scala
+++ b/src/test/scala/DatomicMapping2Spec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith

--- a/src/test/scala/DatomicMappingSpec.scala
+++ b/src/test/scala/DatomicMappingSpec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith

--- a/src/test/scala/DatomicSchema2Spec.scala
+++ b/src/test/scala/DatomicSchema2Spec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith

--- a/src/test/scala/DatomicSchemaQuerySpec.scala
+++ b/src/test/scala/DatomicSchemaQuerySpec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith

--- a/src/test/scala/DatomicSchemaSpec.scala
+++ b/src/test/scala/DatomicSchemaSpec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith

--- a/src/test/scala/DatomicSyntaxSugarSpec.scala
+++ b/src/test/scala/DatomicSyntaxSugarSpec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith

--- a/src/test/scala/DatomicTransacSpec.scala
+++ b/src/test/scala/DatomicTransacSpec.scala
@@ -1,3 +1,5 @@
+import scala.language.reflectiveCalls
+
 import org.specs2.mutable._
 
 import org.junit.runner.RunWith


### PR DESCRIPTION
explicitly importing the required language features (`import scala.language.X`) silences the compiler warnings

There is still a deprecation warning left:

```
[warn] DatomicInception.scala:30:
method offset in class Position is deprecated:
use point instead
[warn]     val isMultiLine = source.beginsWith(pos.offset.get, "\"\"\"")
```
