### PR TITLE
turn TxReport into a regular class

### DIFF
--- a/src/main/scala/DatomicConnection.scala
+++ b/src/main/scala/DatomicConnection.scala
@@ -20,12 +20,11 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 
-class TxReport(
-  val dbBefore: DDatabase,
-  val dbAfter:  DDatabase,
-  val txData:   Seq[DDatom],
-  private val tempids: AnyRef
-) extends TxReportHidden {
+trait TxReport extends TxReportHidden {
+  val dbBefore: DDatabase
+  val dbAfter:  DDatabase
+  val txData:   Seq[DDatom]
+  protected val tempids: AnyRef
 
   override def resolve(id: DId)(implicit db: DDatabase): DLong =
     resolveOpt(id) getOrElse { throw new TempidNotResolved(id) }

--- a/src/main/scala/Utils.scala
+++ b/src/main/scala/Utils.scala
@@ -71,21 +71,21 @@ object Utils {
     import datomic.Connection._
     import datomic.db.Db
 
-    new TxReport(
-      dbBefore = DDatabase(
+    new TxReport {
+      override val dbBefore = DDatabase(
           javaMap.get(DB_BEFORE).asInstanceOf[Db]
-        ),
-      dbAfter  = DDatabase(
+        )
+      override val dbAfter  = DDatabase(
           javaMap.get(DB_AFTER).asInstanceOf[Db]
-        ),
-      txData =
+        )
+      override val txData =
         javaMap.get(TX_DATA)
                .asInstanceOf[java.util.List[datomic.Datom]]
                .asScala
                .map(DDatom(_)(database))
-               .toSeq,
-      tempids = javaMap.get(TEMPIDS).asInstanceOf[AnyRef]
-    )
+               .toSeq
+      override protected val tempids = javaMap.get(TEMPIDS).asInstanceOf[AnyRef]
+    }
   }
 
   def queue2Stream[A](queue: java.util.concurrent.BlockingQueue[A]): Stream[Option[A]] = {


### PR DESCRIPTION
give tempids private visibility, so that temp ids can only be resolved through the resolve methods of TxReport

continues on from pull request #6 
