### PR TITLE
Introduce database and transaction functions

### DIFF
--- a/samples/accounts/build.sbt
+++ b/samples/accounts/build.sbt
@@ -2,7 +2,7 @@ name := "datomisca-accounts-sample"
 
 organization := "pellucidanalytics"
 
-version := "0.2-SNAPSHOT"
+version := "0.3-SNAPSHOT"
 
 scalaVersion := "2.10.0"
 
@@ -10,10 +10,11 @@ fork in test := true
 
 resolvers ++= Seq(
   "datomisca-repo snapshots" at "https://github.com/pellucidanalytics/datomisca-repo/raw/master/snapshots",
+  "datomisca-repo releases"  at "https://github.com/pellucidanalytics/datomisca-repo/raw/master/releases",
   "clojars" at "https://clojars.org/repo"
 )
 
 libraryDependencies ++= Seq(
-  "pellucidanalytics" %% "datomisca" % "0.2-SNAPSHOT",
-  "com.datomic" % "datomic-free" % "0.8.3789"
+  "pellucidanalytics" %% "datomisca" % "0.3-SNAPSHOT",
+  "com.datomic" % "datomic-free" % "0.8.3814"
 )

--- a/samples/accounts/src/main/scala/Accounts.scala
+++ b/samples/accounts/src/main/scala/Accounts.scala
@@ -66,18 +66,18 @@ object AccountsTxData {
   import AccountsSchema._
   val issuer = SchemaEntity.add(DId(Partition.USER))(Props() +
     (name       -> "Issuer") +
-    (balance    -> BigDecimal(0).bigDecimal) +
-    (minBalance -> BigDecimal(-1000).bigDecimal)
+    (balance    -> BigDecimal(0)) +
+    (minBalance -> BigDecimal(-1000))
   )
   val bob = SchemaEntity.add(DId(Partition.USER))(Props() +
     (name       -> "Bob") +
-    (balance    -> BigDecimal(0).bigDecimal) +
-    (minBalance -> BigDecimal(0).bigDecimal)
+    (balance    -> BigDecimal(0)) +
+    (minBalance -> BigDecimal(0))
   )
   val alice = SchemaEntity.add(DId(Partition.USER))(Props() +
     (name       -> "Alice") +
-    (balance    -> BigDecimal(0).bigDecimal) +
-    (minBalance -> BigDecimal(0).bigDecimal)
+    (balance    -> BigDecimal(0)) +
+    (minBalance -> BigDecimal(0))
   )
   val sampleTxData = Seq(issuer, bob, alice)
 
@@ -89,7 +89,7 @@ object AccountsTxData {
         KW(":db/doc") -> note,
         from.ident    -> fromAcc,
         to.ident      -> toAcc,
-        amount.ident  -> transAmount.bigDecimal
+        amount.ident  -> transAmount
       )
     )
   }

--- a/src/main/scala/DatomicOps.scala
+++ b/src/main/scala/DatomicOps.scala
@@ -107,14 +107,13 @@ case class AddIdent(ident: Keyword, partition: Partition = Partition.USER) exten
   override def toString = toNative.toString
 }
 
-case class AddDbFunction(val ident: Keyword, params: Seq[String], code: String, partition: Partition = Partition.USER) extends Operation with Identified with Referenceable {
-  override lazy val id  = DId(partition)
-  override lazy val ref = DRef(ident)
+case class AddDbFunction(val ident: Keyword, params: Seq[String], code: String, partition: Partition = Partition.USER) extends Operation with KeywordIdentified {
+  lazy val ref = DRef(ident)
   val kw = Keyword("add", Some(Namespace.DB))
 
   def toNative: AnyRef =
     datomic.Util.map(
-      Keyword("id", Some(Namespace.DB)).toNative,    id.toNative,
+      Keyword("id", Some(Namespace.DB)).toNative,    DId(partition).toNative,
       Keyword("ident", Some(Namespace.DB)).toNative, ident.toNative,
       Keyword("fn", Some(Namespace.DB)).toNative,    datomic.Peer.function(
         datomic.Util.map(


### PR DESCRIPTION
I’ve done some minor cleaning to `DatomicOps`, and I’ve made a first attempt at introducing database functions. `AddDbFunction` constructs transaction data to add a function to the database. `InvokeTxFunction` constructs transaction data to invoke a database function as a transaction function in a transaction.

I had some problems getting Datomic to accept Java code, so this only supports raw Clojure for now. (The Datomic compiler was complaining about imports when I gave it Java code.)

I’ve added a new sample application to demonstrate transaction functions, which was adapted from here: https://gist.github.com/pelle/2635666

Maybe you have some thoughts about how to improve/generalize the code?

We definitely need to add Datomic functions into the `DatomicData` hierarchy, as inspecting the value of a `:db/fn` attribute will currently throw an exception.
