### PR TITLE
Move Datomic.resolveEntity to be method on TxReport

### DIFF
--- a/src/main/scala/Datomic.scala
+++ b/src/main/scala/Datomic.scala
@@ -230,13 +230,6 @@ trait DatomicFacilities extends DatomicTypeWrapper{
     */
   def fromDatomic[DD <: DatomicData, T](dd: DD)(implicit fd: FromDatomicInj[DD, T]): T = fd.from(dd)
 
-  def resolveEntity(tx: TxReport, id: DId)(implicit db: DDatabase): DEntity = {
-    tx.resolveOpt(id) match {
-      case None    => throw new TempidNotResolved(id)
-      case Some(e) => db.entity(e)
-    }
-  }
-
   /** Converts any data to a Datomic Data (or not if not possible) */
   def toDatomicData(v: Any): DatomicData = v match {
     case s: String => DString(s)

--- a/src/main/scala/DatomicConnection.scala
+++ b/src/main/scala/DatomicConnection.scala
@@ -45,6 +45,9 @@ trait TxReport {
   def resolveOpt(ids: DId*): Seq[Option[Long]] =
     ids map { resolveOpt(_) }
 
+  def resolveEntity(id: DId): DEntity =
+    dbAfter.entity(resolve(id))
+
   lazy val tempidMap = new Map[DId, Long] {
     override def get(tempId: DId) = resolveOpt(tempId)
     override def iterator = throw new UnsupportedOperationException

--- a/src/test/scala/DatomicTxSpec.scala
+++ b/src/test/scala/DatomicTxSpec.scala
@@ -552,7 +552,7 @@ class DatomicTxSpec extends Specification {
         database.entity(id) !== beNull
         
         database.entity(1234L) must throwA[datomisca.EntityNotFoundException]
-        Datomic.resolveEntity(tx, DId(Partition.USER)) must throwA[datomisca.EntityNotFoundException]
+        tx.resolveEntity(DId(Partition.USER)) must throwA[datomisca.EntityNotFoundException]
       }
     }
 


### PR DESCRIPTION
This ensures that the temporary id and the entity are resolved from the same database value!

This fixes #49.
