### PR TITLE
A schema manager

### DIFF
--- a/extras/src/main/scala/datomisca/schemaManagement.scala
+++ b/extras/src/main/scala/datomisca/schemaManagement.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012 Pellucid and Zenexity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package datomisca
+
+import scala.language.reflectiveCalls
+
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+import scala.util.Try
+
+
+object SchemaManager {
+
+  def hasAttribute(attributeIdent: Keyword)(implicit db: DDatabase): Boolean =
+    Try {
+      db.entity(attributeIdent)
+    } .map { entity =>
+      entity(Namespace.DB.INSTALL / "_attribute")
+    } .isSuccess
+
+  private val schemaTagQuery = Query("""
+      [:find ?e
+       :in $ ?schemaTag ?schemaName
+       :where [?e ?schemaTag ?schemaName]]
+    """)
+
+  private[datomisca] def hasSchema(schemaTag: Keyword, schemaName: String)(implicit db: DDatabase): Boolean =
+    ! Datomic.q(schemaTagQuery, db, DRef(schemaTag), DString(schemaName)).isEmpty
+
+  private[datomisca] def ensureSchemaTag(schemaTag: Keyword)(implicit conn: Connection): Future[Unit] =
+    future {
+      hasAttribute(schemaTag)(conn.database)
+    } flatMap {
+      case true  => Future.successful(())
+      case false =>
+        Datomic.transact(
+          Attribute(schemaTag, SchemaType.string, Cardinality.one)
+            .withDoc("Name of schema installed by this transaction")
+            .withIndex(true)
+        ) map { _ => () }
+    }
+
+  private[datomisca] def ensureSchemas(
+      schemaTag:   Keyword,
+      schemaMap:   Map[String, (Seq[String], Seq[Seq[Operation]])],
+      schemaNames: String*)
+     (implicit conn: Connection)
+     : Future[Unit] = {
+    Future.traverse(schemaNames) { schemaName =>
+      future {
+        hasSchema(schemaTag, schemaName)(conn.database)
+      } flatMap {
+        case true  =>
+          Future.successful(())
+        case false =>
+          val (requires, txDatas) = schemaMap(schemaName)
+          ensureSchemas(schemaTag, schemaMap, requires: _*) flatMap { _ =>
+            if (txDatas.isEmpty) {
+              throw new RuntimeException(s"DatomicSchemaManager.ensureSchemas: no data provided for schema ${schemaName}")
+            } else {
+              Future.traverse(txDatas) { txData =>
+                Datomic.transact(
+                  txData :+
+                  Fact.add(DId(Partition.TX))(schemaTag -> schemaName)
+                ) map { _ => () }
+              }
+            }
+          }
+      }
+    } map { _ => () }
+  }
+
+  def installSchema(
+      schemaTag:   Keyword,
+      schemaMap:   Map[String, (Seq[String], Seq[Seq[Operation]])],
+      schemaNames: String*)
+     (implicit conn: Connection)
+     : Future[Unit] =
+    for {
+      _ <- ensureSchemaTag(schemaTag)
+      _ <- ensureSchemas(schemaTag, schemaMap, schemaNames: _*)
+    } yield ()
+
+}

--- a/tests/src/test/scala/datomisca/SchemaManagerSpec.scala
+++ b/tests/src/test/scala/datomisca/SchemaManagerSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2012 Pellucid and Zenexity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package datomisca
+
+import org.specs2.mutable._
+
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+
+@RunWith(classOf[JUnitRunner])
+class SchemaManagerSpec extends Specification {
+
+  val schemaTag = Datomic.KW(":my-schema-tag")
+
+  case object SchemaA {
+    val attrA = Attribute(Datomic.KW(":attrA"), SchemaType.string, Cardinality.one)
+
+    val name     = "SchemaA"
+    val requires = Seq.empty[String]
+    val txData   = Seq(attrA)
+  }
+  case object SchemaB {
+    val attrB = Attribute(Datomic.KW(":attrB"), SchemaType.string, Cardinality.one)
+
+    val name     = "SchemaB"
+    val requires = Seq(SchemaA.name)
+    val txData   = Seq(attrB)
+  }
+
+  case object SchemaC {
+    val attrC = Attribute(Datomic.KW(":attrC"), SchemaType.string, Cardinality.one)
+
+    val name     = "SchemaC"
+    val requires = Seq(SchemaB.name)
+    val txData   = Seq(attrC)
+  }
+
+  val schemaMap = Map(
+      SchemaA.name ->
+        (SchemaA.requires,
+          Seq(SchemaA.txData)),
+      SchemaB.name ->
+        (SchemaB.requires,
+          Seq(SchemaB.txData)),
+      SchemaC.name ->
+        (SchemaC.requires,
+          Seq(SchemaC.txData))
+    )
+
+  "Schema Manager" should {
+
+    val uri = "datomic:mem://SchemaManagerSpec"
+    println(s"created DB with uri $uri: ${Datomic.createDatabase(uri)}")
+    implicit val conn = Datomic.connect(uri)
+
+    "provision schemas if needed" in {
+
+      Await.result(
+        for {
+          _ <- SchemaManager.installSchema(schemaTag, schemaMap, SchemaA.name)
+        } yield {
+          implicit val db = conn.database
+
+          SchemaManager.hasAttribute(SchemaA.attrA.ident) must beTrue
+          SchemaManager.hasAttribute(SchemaB.attrB.ident) must beFalse
+
+          SchemaManager.hasSchema(schemaTag, SchemaA.name) must beTrue
+          SchemaManager.hasSchema(schemaTag, SchemaB.name) must beFalse
+        },
+        Duration("10 seconds")
+      )
+
+
+      Await.result(
+        for {
+          _ <- SchemaManager.installSchema(schemaTag, schemaMap, SchemaC.name)
+        } yield {
+          implicit val db = conn.database
+
+          SchemaManager.hasAttribute(SchemaB.attrB.ident) must beTrue
+          SchemaManager.hasAttribute(SchemaC.attrC.ident) must beTrue
+
+          SchemaManager.hasSchema(schemaTag, SchemaB.name) must beTrue
+          SchemaManager.hasSchema(schemaTag, SchemaC.name) must beTrue
+        },
+        Duration("10 seconds")
+      )
+
+      success
+    }
+  }
+
+}


### PR DESCRIPTION
manages a schema as an acyclic graph, and tags the nodes of the graph when they are first transacted
a direct port of https://github.com/rkneufeld/conformity/blob/master/src/io/rkn/conformity.clj and https://github.com/Datomic/day-of-datomic/blob/master/src/datomic/samples/schema.clj
