### PR TITLE
Eliminate method overloading in DDatabase

### DIFF
--- a/core/src/main/scala/datomisca/Entity.scala
+++ b/core/src/main/scala/datomisca/Entity.scala
@@ -31,7 +31,8 @@ object Entity extends DatomicTypeWrapper with EntityOpsMacros {
     *
     * @param id the DLong of a targeted real [[DId]]
     */
-  def retract[T](id: T)(implicit ev: FromFinalId[T]) = RetractEntity(ev.from(id))
+  def retract[T](id: T)(implicit ev: AsPermanentEntityId[T]) =
+    RetractEntity(ev.conv(id))
 
   /** Creates a Multiple-"Add" targeting a single [[DId]]
     *
@@ -53,10 +54,10 @@ object Entity extends DatomicTypeWrapper with EntityOpsMacros {
     *
     * @param id the targeted [[DId]] which must be a [[FinalId]]
     */
-  def add[T](id: T)(props: (Keyword, DWrapper)*)(implicit ev: ToDId[T]) = {
+  def add[T](id: T)(props: (Keyword, DWrapper)*)(implicit ev: AsEntityId[T]) = {
     val builder = Map.newBuilder[Keyword, DatomicData]
     for (p <- props) builder += (p._1 -> p._2.asInstanceOf[DWrapperImpl].underlying)
-    new AddEntity(ev.to(id), builder.result)
+    new AddEntity(ev.conv(id), builder.result)
   }
 
   /** Creates a Multiple-"Add" targeting a single [[DId]] from a simple Map[ [[Keyword]], [[DatomicData]] ]
@@ -80,7 +81,8 @@ object Entity extends DatomicTypeWrapper with EntityOpsMacros {
     * @param id the targeted [[DId]] which must be a [[FinalId]]
     * @param props the map containing all tupled (keyword, value)
     */
-  def add[T](id: T, props: Map[Keyword, DatomicData])(implicit ev: ToDId[T]) = new AddEntity(ev.to(id), props)
+  def add[T](id: T, props: Map[Keyword, DatomicData])(implicit ev: AsEntityId[T]) =
+    new AddEntity(ev.conv(id), props)
 
 
   /** Creates a Multiple-"Add" targeting a single [[DId]] and using a [[PartialAddEntity]]
@@ -98,7 +100,8 @@ object Entity extends DatomicTypeWrapper with EntityOpsMacros {
     * @param id the targeted [[DId]] which must be a [[FinalId]]
     * @param props a [[PartialAddEntity]] containing tuples (keyword, value)
     */
-  def add[T](id: T, partial: PartialAddEntity)(implicit ev: ToDId[T]) = new AddEntity(ev.to(id), partial.props)
+  def add[T](id: T, partial: PartialAddEntity)(implicit ev: AsEntityId[T]) =
+    new AddEntity(ev.conv(id), partial.props)
 
   /** Creates a [[PartialAddEntity]] which is basically a AddToEntity without the DId part (''technical API'').
     *

--- a/core/src/main/scala/datomisca/Fact.scala
+++ b/core/src/main/scala/datomisca/Fact.scala
@@ -34,7 +34,8 @@ object Fact extends DatomicTypeWrapper {
     *             where value can be any String/Long/Double/Float/Boolean/Date/BigInt/BigDec/DRef
     *             converted to [[DatomicData]] using [[toDWrapper]] implicit conversion
     */
-  def add[T](id: T)(prop: (Keyword, DWrapper))(implicit ev: ToDId[T]) = AddFact(ev.to(id), prop._1, prop._2.asInstanceOf[DWrapperImpl].underlying)
+  def add[T](id: T)(prop: (Keyword, DWrapper))(implicit ev: AsEntityId[T]) =
+    AddFact(ev.conv(id), prop._1, prop._2.asInstanceOf[DWrapperImpl].underlying)
 
   /** Creates a single Retract operation targeting a given [[DId]]
     *
@@ -50,7 +51,8 @@ object Fact extends DatomicTypeWrapper {
     *             where value can be any String/Long/Double/Float/Boolean/Date/BigInt/BigDec/DRef
     *             converted to [[DatomicData]] using [[toDWrapper]] implicit conversion
     */
-  def retract[T](id: T)(prop: (Keyword, DWrapper))(implicit ev: FromFinalId[T]) = RetractFact(ev.from(id), prop._1, prop._2.asInstanceOf[DWrapperImpl].underlying)
+  def retract[T](id: T)(prop: (Keyword, DWrapper))(implicit ev: AsPermanentEntityId[T]) =
+    RetractFact(ev.conv(id), prop._1, prop._2.asInstanceOf[DWrapperImpl].underlying)
 
   /** Helper: creates a special AddToEntity for creating a new Partition
     *

--- a/extras/src/main/scala/datomisca/DatomicMapping.scala
+++ b/extras/src/main/scala/datomisca/DatomicMapping.scala
@@ -25,7 +25,7 @@ object DatomicMapping
 {
   def fromEntity[A](e: DEntity)(implicit er: EntityReader[A]): A = er.read(e)
 
-  def toEntity[T, A](id: T)(a: A)(implicit ev: ToDId[T], ew: PartialAddEntityWriter[A]): AddEntity = new AddEntity(ev.to(id), ew.write(a).props)
+  def toEntity[T, A](id: T)(a: A)(implicit ev: AsEntityId[T], ew: PartialAddEntityWriter[A]): AddEntity = new AddEntity(ev.conv(id), ew.write(a).props)
 
   val ID = Attribute( Namespace.DB / "id", SchemaType.long, Cardinality.one)
 

--- a/extras/src/main/scala/datomisca/SchemaEntity.scala
+++ b/extras/src/main/scala/datomisca/SchemaEntity.scala
@@ -20,7 +20,8 @@ package datomisca
 object SchemaEntity {
   /** AddEntity based on Schema attributes 
     */
-  def add[T](id: T)(props: Props)(implicit ev: ToDId[T]): AddEntity = new AddEntity(ev.to(id), props.convert.props)
+  def add[T](id: T)(props: Props)(implicit ev: AsEntityId[T]): AddEntity =
+    new AddEntity(ev.conv(id), props.convert.props)
 
   class SchemaEntityBuilder {
 
@@ -34,7 +35,8 @@ object SchemaEntity {
       this
     }
 
-    def withId[T](id: T)(implicit ev: ToDId[T]): AddEntity = new AddEntity(ev.to(id), builder.result)
+    def withId[T](id: T)(implicit ev: AsEntityId[T]): AddEntity =
+      new AddEntity(ev.conv(id), builder.result)
   }
 
   def newBuilder: SchemaEntityBuilder = new SchemaEntityBuilder

--- a/extras/src/main/scala/datomisca/SchemaFact.scala
+++ b/extras/src/main/scala/datomisca/SchemaFact.scala
@@ -21,21 +21,21 @@ object SchemaFact {
   /** add based on Schema attributes 
     */
   def add[T, DD <: DatomicData, Card <: Cardinality, A](id: T)(prop: (Attribute[DD, Card], A))
-    (implicit ev: ToDId[T], attrC: Attribute2PartialAddEntityWriter[DD, Card, A]): AddFact = {
+    (implicit ev: AsEntityId[T], attrC: Attribute2PartialAddEntityWriter[DD, Card, A]): AddFact = {
     val entityWriter = attrC.convert(prop._1)
     val partial = entityWriter.write(prop._2)
     val (kw: Keyword, value: DatomicData) = partial.props.head
-    AddFact(ev.to(id), kw, value)
+    AddFact(ev.conv(id), kw, value)
   }
 
   /** retract based on Schema attributes 
     */
   def retract[T, DD <: DatomicData, Card <: Cardinality, A](id: T)(prop: (Attribute[DD, Card], A))
-    (implicit ev: FromFinalId[T], attrC: Attribute2PartialAddEntityWriter[DD, Card, A]): RetractFact = {
+    (implicit ev: AsPermanentEntityId[T], attrC: Attribute2PartialAddEntityWriter[DD, Card, A]): RetractFact = {
     val entityWriter = attrC.convert(prop._1)
     val partial = entityWriter.write(prop._2)
     val (kw: Keyword, value: DatomicData) = partial.props.head
-    RetractFact(ev.from(id), kw, value)
+    RetractFact(ev.conv(id), kw, value)
   }
 
 }


### PR DESCRIPTION
Make use of `FromFinalId` type class and new `FromPointT` type class to eliminate much of the need for method overloading in `DDatabase`.
