### PR TITLE
DDatabase throws EntityNotFoundException

### DIFF
--- a/common/src/main/scala/datomisca/DDatabase.scala
+++ b/common/src/main/scala/datomisca/DDatabase.scala
@@ -71,29 +71,29 @@ class DDatabase(val underlying: datomic.Database) extends DatomicData {
 
   /** Returns the entity for the given entity id.
     *
-    * @param id an entity id.
+    * This will return an empty [[DEntity]], if there
+    * are no facts about the given entity id. The
+    * :db/id of the entity will be the given id.
+    *
+    * @param id
+    *     an entity id.
     * @return an entity.
-    * @throws EntityNotFoundException if there is no such entity.
     */
-  def entity[T](id: T)(implicit ev: AsPermanentEntityId[T]): DEntity = {
-    val l = ev.conv(id)
-    wrapEntity(l.toString, underlying.entity(l))
-  }
+  def entity[T](id: T)(implicit ev: AsPermanentEntityId[T]): DEntity =
+    new DEntity(underlying.entity(ev.conv(id)))
 
   /** Returns the entity for the given keyword.
     *
-    * @param kw a keyword.
+    * This will return an empty [[DEntity]], if there
+    * are no facts about the given entity ident. The
+    * :db/id of the entity will null.
+    *
+    * @param kw
+    *   a keyword.
     * @return an entity.
-    * @throws EntityNotFoundException if there is no such entity.
     */
   def entity(kw: Keyword): DEntity =
-    wrapEntity(kw.toString, underlying.entity(kw.toNative))
-
-  private def wrapEntity(id: String, entity: datomic.Entity): DEntity =
-    if (entity.keySet.isEmpty)
-      throw new EntityNotFoundException(id)
-    else
-      DEntity(entity)
+    new DEntity(underlying.entity(kw.toNative))
 
 
   /** Returns the value of the database as of some point t, inclusive.

--- a/common/src/main/scala/datomisca/exceptions.scala
+++ b/common/src/main/scala/datomisca/exceptions.scala
@@ -19,9 +19,6 @@ package datomisca
 
 class DatomicException(msg: String) extends Exception(msg)
 
-class EntityNotFoundException(id: String)
-  extends DatomicException(s"Datomic Error: entity not found with id($id)")
-
 class TempidNotResolved(id: DId)
   extends DatomicException(s"Datomic Error: entity not found with id($id)")
 

--- a/tests/src/test/scala/datomisca/DatomicTxSpec.scala
+++ b/tests/src/test/scala/datomisca/DatomicTxSpec.scala
@@ -576,8 +576,8 @@ class DatomicTxSpec extends Specification {
         val id = tx.resolve(idToto)
         Datomic.database.entity(id) !== beNull
         
-        Datomic.database.entity(1234L) must throwA[datomisca.EntityNotFoundException]
-        tx.resolveEntity(DId(Partition.USER)) must throwA[datomisca.EntityNotFoundException]
+        Datomic.database.entity(1234L).keySet must beEmpty
+        tx.resolveEntity(DId(Partition.USER)).keySet must beEmpty
       }
 
       success


### PR DESCRIPTION
I am using TxReport instances and retrieving the "before"entity, which does not always exist.
Having to handle exceptions makes the code rather ugly. 

Throwing exceptions is generally considered non-idiomatic.

Can the API be changed to return Option?
