### PR TITLE
Query on attribute fails because it returns java.lang.Integer

### DIFF
--- a/common/src/main/scala/datomisca/DatomicData.scala
+++ b/common/src/main/scala/datomisca/DatomicData.scala
@@ -32,6 +32,8 @@ private[datomisca] object DatomicData {
     case b: java.lang.Boolean => DBoolean(b)
     // :db.type/long
     case l: java.lang.Long => DLong(l)
+    // attribute id
+    case i: java.lang.Integer => DLong(i.toLong)
     // :db.type/float
     case f: java.lang.Float => DFloat(f)
     // :db.type/double

--- a/tests/src/test/scala/datomisca/DatomicQuery2Spec.scala
+++ b/tests/src/test/scala/datomisca/DatomicQuery2Spec.scala
@@ -202,5 +202,35 @@ class DatomicQuery2Spec extends Specification {
 
       success
     }
+    
+     "10 - pure query attribute" in {
+      implicit val conn = Datomic.connect(uri)
+      val query1 = Query("""
+        [ :find ?e 
+          :in $ ?char
+          :where  [ ?e :person/name ?n ]
+                  [ ?e :person/character ?char ]
+        ]
+      """)
+      
+       val query2 = Query("""
+        [:find ?a ?v :in $ ?e  :where [ ?e ?a ?v _]] 
+      """)
+      
+
+      Datomic.q(
+        query1,
+        Datomic.database,
+        DRef(Datomic.KW(":person.character/violent"))
+      ) map {
+        case (e:DLong) => {
+           val result = Datomic.q(query2, Datomic.database,e) 
+           result must not be empty
+           println(result)
+        
+        }
+      } should  not (throwA[UnexpectedDatomicTypeException])
+     
+    }
   }
 }


### PR DESCRIPTION
A query of the form

[:find ?a ?v :in $ ?e  :where [ ?e ?a ?v _]] 
fails because datomic returns an Integer which is not handled by DatomicData.toDatomicData

Redone against develop
