### PR TITLE
Use Keyword views to R/W ref attributes

### DIFF
--- a/common/src/main/scala/datomisca/DatomicData.scala
+++ b/common/src/main/scala/datomisca/DatomicData.scala
@@ -184,11 +184,16 @@ sealed trait ToDRef[T] {
 }
 
 object ToDRef {
-  implicit val keyword2DRef: ToDRef[Keyword] = new ToDRef[Keyword] { def toDRef(kw: Keyword) = new DRef(Left(kw)) }
+
   implicit val long2DRef:    ToDRef[Long]    = new ToDRef[Long]    { def toDRef(l:  Long)    = new DRef(Right(DId(l))) }
   implicit val dlong2DRef:   ToDRef[DLong]   = new ToDRef[DLong]   { def toDRef(l:  DLong)   = new DRef(Right(DId(l))) }
 
   implicit def did2DRef[I <: DId]: ToDRef[I] = new ToDRef[I]       { def toDRef(i:  I)       = new DRef(Right(i)) }
+
+  implicit def keyword2DRef[K](implicit toKeyword: K => Keyword): ToDRef[K] =
+    new ToDRef[K] {
+      def toDRef(k: K) = new DRef(Left(toKeyword(k)))
+    }
 }
 
 sealed trait DId extends DatomicData

--- a/extras/src/main/scala/datomisca/attribute2EntityReader.scala
+++ b/extras/src/main/scala/datomisca/attribute2EntityReader.scala
@@ -125,21 +125,21 @@ object Attribute2EntityReaderCast {
       }
     }
 
-  implicit val attr2EntityReaderCastKeyword =
-    new Attribute2EntityReaderCast[DRef, Cardinality.one.type, Keyword] {
-      override def convert(attr: Attribute[DRef, Cardinality.one.type]) = new EntityReader[Keyword] {
+  implicit def attr2EntityReaderCastKeyword[K](implicit fromKeyword: Keyword => K) =
+    new Attribute2EntityReaderCast[DRef, Cardinality.one.type, K] {
+      override def convert(attr: Attribute[DRef, Cardinality.one.type]) = new EntityReader[K] {
         override def read(entity: DEntity) =
-          entity(attr.ident).asInstanceOf[DKeyword].underlying
+          fromKeyword(entity(attr.ident).asInstanceOf[DKeyword].underlying)
       }
     }
 
-  implicit val attr2EntityReaderCastManyKeyword =
-    new Attribute2EntityReaderCast[DRef, Cardinality.many.type, Set[Keyword]] {
-      override def convert(attr: Attribute[DRef, Cardinality.many.type]) = new EntityReader[Set[Keyword]] {
+  implicit def attr2EntityReaderCastManyKeyword[K](implicit fromKeyword: Keyword => K) =
+    new Attribute2EntityReaderCast[DRef, Cardinality.many.type, Set[K]] {
+      override def convert(attr: Attribute[DRef, Cardinality.many.type]) = new EntityReader[Set[K]] {
         override def read(entity: DEntity) =
           entity.get(attr.ident) map { case DColl(elems) =>
             elems.map {
-              case DKeyword(keyword) => keyword
+              case DKeyword(keyword) => fromKeyword(keyword)
               case _ => throw new EntityMappingException("expected DatomicData to be DKeyword")
             } .toSet
           } getOrElse (Set.empty)


### PR DESCRIPTION
- Make the `ToDRef` type class more flexible: allow types viewable as `Keyword` to be lifted into a `DRef`.
- And similarly replace `Attribute2EntityReaderCast[DRef, Card, Keyword]` with `Attribute2EntityReaderCast[DRef, Card, K]` with implicit `Keyword => K`.
