### PR TITLE
Correct definition of transaction data for new partitions

### DIFF
--- a/core/src/main/scala/datomisca/Fact.scala
+++ b/core/src/main/scala/datomisca/Fact.scala
@@ -64,8 +64,8 @@ object Fact extends DatomicTypeWrapper {
     */
   def partition(partition: Partition) =
     new AddEntity(DId(Partition.DB), Map(
-      Namespace.DB / "ident" -> DString(partition.toString),
-      Namespace.DB.INSTALL / "_partition" -> DString("db.part/db")
+      Namespace.DB / "ident"              -> DKeyword(partition.keyword),
+      Namespace.DB.INSTALL / "_partition" -> DKeyword(Partition.DB.keyword)
     ))
 
 }


### PR DESCRIPTION
I guess Datomic was forgiving before, when keywords were being passed as strings. Now that we support keywords as Datomic data, this will pass the ident and partition as Clojure keywords.
