### PR TITLE
Optimize TxReport (resolves performance bug)

### DIFF
--- a/common/src/main/scala/datomisca/DDatabase.scala
+++ b/common/src/main/scala/datomisca/DDatabase.scala
@@ -199,7 +199,7 @@ class DDatabase(val underlying: datomic.Database) extends DatomicData {
 
     val javaMap: java.util.Map[_, _] = underlying.`with`(datomicOps)
 
-    TxReport.toTxReport(javaMap)(this)
+    new TxReport(javaMap)
   }
 
   /** Returns the value of the database containing only Datoms

--- a/core/src/main/scala/datomisca/Connection.scala
+++ b/core/src/main/scala/datomisca/Connection.scala
@@ -91,17 +91,14 @@ class Connection(
       }
 
     future map { javaMap: java.util.Map[_, _] =>
-      TxReport.toTxReport(javaMap)(database)
+      new TxReport(javaMap)
     }
   }
 
   def transact(op: Operation)(implicit ex: ExecutionContext): Future[TxReport] = transact(Seq(op))
   def transact(op: Operation, ops: Operation *)(implicit ex: ExecutionContext): Future[TxReport] = transact(Seq(op) ++ ops)
 
-  def txReportQueue: TxReportQueue = new TxReportQueue(
-      database = database,
-      queue    = connection.txReportQueue
-    )
+  def txReportQueue: TxReportQueue = new TxReportQueue(connection.txReportQueue)
 
   def removeTxReportQueue: Unit = connection.removeTxReportQueue
 

--- a/core/src/main/scala/datomisca/TxReportQueue.scala
+++ b/core/src/main/scala/datomisca/TxReportQueue.scala
@@ -20,14 +20,13 @@ import java.{util => ju}
 import java.util.{concurrent => juc}
 
 class TxReportQueue(
-    val database: DDatabase,
     val queue:    juc.BlockingQueue[ju.Map[_, _]]
 ) {
 
 
   lazy val stream: Stream[Option[TxReport]] = queue2Stream[ju.Map[_, _]](queue).map{ 
     case None => None
-    case Some(javaMap) => Some(TxReport.toTxReport(javaMap)(database))
+    case Some(javaMap) => Some(new TxReport(javaMap))
   }
 
   private def queue2Stream[A](queue: juc.BlockingQueue[A]): Stream[Option[A]] = {


### PR DESCRIPTION
This pull request solves a major performance bug with respect to TxReport. This was particularly noticeable when transacting significant volumes of data, as the contents of the transaction report was being eagerly wrapped into Scala data structures, and thus generating vast amounts of garbage.

@ezhulenev, I strongly suspect this was the reason the garbage collection was going crazy.
