### PR TITLE
Mark Datomic calls that may result in network access as blocking

### DIFF
--- a/common/src/main/scala/datomisca/DDatabase.scala
+++ b/common/src/main/scala/datomisca/DDatabase.scala
@@ -17,7 +17,6 @@
 package datomisca
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.blocking
 
 import java.util.{Date => JDate}
 
@@ -84,9 +83,7 @@ class DDatabase(val underlying: datomic.Database) extends DatomicData {
     * @return an entity.
     */
   def entity[T](id: T)(implicit ev: AsPermanentEntityId[T]): DEntity =
-    new DEntity(blocking {
-      underlying.entity(ev.conv(id))
-    })
+    new DEntity(underlying.entity(ev.conv(id)))
 
   /** Returns the entity for the given keyword.
     *
@@ -99,9 +96,7 @@ class DDatabase(val underlying: datomic.Database) extends DatomicData {
     * @return an entity.
     */
   def entity(kw: Keyword): DEntity =
-    new DEntity(blocking {
-      underlying.entity(kw.toNative)
-    })
+    new DEntity(underlying.entity(kw.toNative))
 
 
   /** Returns the value of the database as of some point t, inclusive.
@@ -140,9 +135,7 @@ class DDatabase(val underlying: datomic.Database) extends DatomicData {
     * @throws Exception if no entity is found.
     */
   def entid(kw: Keyword): Long =
-    Option {
-      blocking { underlying.entid(kw.toNative) }
-    } match {
+    Option { underlying.entid(kw.toNative) } match {
       case None      => throw new DatomiscaException(s"entity id for keyword $kw not found")
       case Some(eid) => eid.asInstanceOf[Long]
     }
@@ -177,9 +170,7 @@ class DDatabase(val underlying: datomic.Database) extends DatomicData {
     * @throws Exception if no keyword is found
     */
   def ident[T](id: T)(implicit ev: AsPermanentEntityId[T]): Keyword =
-    Option {
-      blocking { underlying.ident(ev.conv(id)) }
-    } match {
+    Option { underlying.ident(ev.conv(id)) } match {
       case None     => throw new DatomiscaException(s"ident keyword for entity id $id not found")
       case Some(kw) => Keyword(kw.asInstanceOf[clojure.lang.Keyword])
     }

--- a/common/src/main/scala/datomisca/DEntity.scala
+++ b/common/src/main/scala/datomisca/DEntity.scala
@@ -34,7 +34,7 @@ class DEntity(val entity: datomic.Entity) extends DatomicData {
 
   def get(keyword: Keyword): Option[DatomicData] =
     Option {
-      blocking { entity.get(keyword.toNative) }
+      entity.get(keyword.toNative)
     } map (DatomicData.toDatomicData(_))
 
   def apply(keyword: String): DatomicData =
@@ -42,7 +42,7 @@ class DEntity(val entity: datomic.Entity) extends DatomicData {
 
   def get(keyword: String): Option[DatomicData] =
     Option {
-      blocking { entity.get(keyword) }
+      entity.get(keyword)
     } map (DatomicData.toDatomicData(_))
 
   def as[T](keyword: Keyword)(implicit fdat: FromDatomicCast[T]): T =
@@ -66,9 +66,7 @@ class DEntity(val entity: datomic.Entity) extends DatomicData {
     val iter = blocking { entity.keySet } .iterator
     while (iter.hasNext) {
       val key = iter.next()
-      builder += (key -> DatomicData.toDatomicData(
-        blocking { entity.get(key) }
-      ))
+      builder += (key -> DatomicData.toDatomicData(entity.get(key)))
     }
     builder.result
   }


### PR DESCRIPTION
Make use of [scala.concurrent.blocking](http://www.scala-lang.org/api/current/scala/concurrent/package.html#blocking) (see [scala-user discussion](https://groups.google.com/d/topic/scala-user/XIhVwRZiucE/discussion)).

(Query and entity access seem to be the crucial cases to cover. Not sure quite how to handle raw index access.)
