### PR TITLE
Fix change detection logic in SchemaManager

### DIFF
--- a/core/src/main/scala/datomisca/schemaManagement.scala
+++ b/core/src/main/scala/datomisca/schemaManagement.scala
@@ -62,11 +62,11 @@ object SchemaManager {
      : Future[Boolean] = {
     Future.traverse(schemaNames) { schemaName =>
       val (requires, txDatas) = schemaMap(schemaName)
-      ensureSchemas(schemaTag, schemaMap, requires: _*) flatMap { _ =>
+      ensureSchemas(schemaTag, schemaMap, requires: _*) flatMap { dependentsChanged =>
         if (txDatas.isEmpty) {
           throw new DatomiscaException(s"No schema data provided for schema ${schemaName}")
         } else if (hasSchema(schemaTag, schemaName)(conn.database)) {
-          Future.successful(false)
+          Future.successful(dependentsChanged)
         } else {
           Future.traverse(txDatas) { txData =>
             Datomic.transact(


### PR DESCRIPTION
bug originated in 574d262380 in pull request #95

The change flag of the dependents need to be propagated up the recursive calls.

The tests are now a little more expansive and cover the case of updates.
