### PR TITLE
extend ToDatomic for Datom to support querying over datoms

### DIFF
--- a/core/src/main/scala/datomisca/toAndFromDatomicInstances.scala
+++ b/core/src/main/scala/datomisca/toAndFromDatomicInstances.scala
@@ -163,6 +163,7 @@ trait ToDatomicImplicits {
   }
 
   implicit val dbConv = ToDatomic[datomic.Database, Database](_.underlying)
+  implicit val datomConv = ToDatomic[datomic.Datom, Datom](_.underlying)
   implicit val rulesConv = ToDatomic[clojure.lang.IPersistentCollection, QueryRules](_.edn)
 
 }

--- a/integration/src/it/scala/datomisca/BindingSpec.scala
+++ b/integration/src/it/scala/datomisca/BindingSpec.scala
@@ -88,4 +88,19 @@ class BindingSpec
     res should contain ("John")
     res should contain ("Jane")
   }
+
+  it can "bind a collection of datoms" in withDatomicDB { implicit conn =>
+    val query = Query("""
+        [:find ?e
+         :in $ ?attrId
+         :where [?e ?attrId]]
+      """)
+
+    val ds = conn.database.datoms(Database.AEVT, Attribute.doc)
+
+    val res = Datomic.q(query, ds, conn.database.entid(Attribute.doc))
+
+    res should contain (0)
+  }
+
 }


### PR DESCRIPTION
support the use of a collection of datoms as a database/datasource
