### PR TITLE
implement concatenation for QueryRules

### DIFF
--- a/macros/src/main/scala/datomisca/query.scala
+++ b/macros/src/main/scala/datomisca/query.scala
@@ -18,8 +18,17 @@ package datomisca
 
 abstract class AbstractQuery(val query: clojure.lang.IPersistentMap)
 
-final class QueryRules(val edn: clojure.lang.IPersistentVector) extends AnyVal {
+final class QueryRules(val edn: clojure.lang.PersistentVector) extends AnyVal {
   override def toString = edn.toString
+
+  def ++(that: QueryRules): QueryRules = {
+    var t: clojure.lang.ITransientCollection = this.edn.asTransient()
+    val i = that.edn.iterator()
+    while (i.hasNext) {
+      t = t.conj(i.next())
+    }
+    new QueryRules(t.persistent().asInstanceOf[clojure.lang.PersistentVector])
+  }
 }
 
 object Query extends macros.QueryMacros


### PR DESCRIPTION
- to get access to an iterator, we need the rules to be PersistentVector, rather than IPersistentVector
- the transient vector needs to be upcast to get the visibility to the conj and persistent methods, which then requires a corresponding down cast
