### PR TITLE
correct and improve SchemaFact.add/retract and SchemaEntityBuilder

### DIFF
--- a/core/src/main/scala/datomisca/Attribute2FactWriter.scala
+++ b/core/src/main/scala/datomisca/Attribute2FactWriter.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 Pellucid and Zenexity
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package datomisca
+
+import scala.annotation.implicitNotFound
+
+
+@implicitNotFound("There is no writer for type ${T} given an attribute with Datomic type ${DD} and cardinality ${Card}")
+trait Attribute2FactWriter[DD <: AnyRef, Card <: Cardinality, T] {
+  def convert(attr: Attribute[DD, Card], t: T): (Keyword, AnyRef)
+  def convert(attrVal: (Attribute[DD, Card], T)): (Keyword, AnyRef) = convert(attrVal._1, attrVal._2)
+}
+
+object Attribute2FactWriter {
+
+  implicit def oneValue[DD <: AnyRef, Card <: Cardinality, T](implicit ev: ToDatomic[DD, T]) =
+    new Attribute2FactWriter[DD, Card, T] {
+      override def convert(attr: Attribute[DD, Card], t: T) =
+        (attr.ident -> ev.to(t))
+    }
+
+
+  implicit def oneRef[Card <: Cardinality, T](implicit ev: AsDatomicRef[T]) =
+    new Attribute2FactWriter[DatomicRef.type, Card, T] {
+      override def convert(attr: Attribute[DatomicRef.type, Card], t: T) =
+        (attr.ident -> ev.toDatomicRef(t))
+    }
+
+
+  implicit def oneIdView[Card <: Cardinality, T, U](implicit ev: T <:< IdView[U]) =
+    new Attribute2FactWriter[DatomicRef.type, Card, T] {
+      override def convert(attr: Attribute[DatomicRef.type, Card], t: T) =
+        (attr.ident -> (ev(t).id: java.lang.Long))
+    }
+
+}

--- a/core/src/main/scala/datomisca/SchemaFact.scala
+++ b/core/src/main/scala/datomisca/SchemaFact.scala
@@ -20,22 +20,18 @@ package datomisca
 object SchemaFact {
   /** add based on Schema attributes 
     */
-  def add[T, DD <: AnyRef, Card <: Cardinality, A](id: T)(prop: (Attribute[DD, Card], A))
-    (implicit ev: AsEntityId[T], attrC: Attribute2PartialAddEntityWriter[DD, Card, A]): AddFact = {
-    val entityWriter = attrC.convert(prop._1)
-    val partial = entityWriter.write(prop._2)
-    val (kw: Keyword, value: AnyRef) = partial.props.head
-    new AddFact(ev.conv(id), kw, value)
+  def add[T, DD <: AnyRef, Card <: Cardinality, A](id: T)(attrVal: (Attribute[DD, Card], A))
+    (implicit ev1: AsEntityId[T], ev2: Attribute2FactWriter[DD, Card, A]): AddFact = {
+    val (kw: Keyword, value: AnyRef) = ev2.convert(attrVal)
+    new AddFact(ev1.conv(id), kw, value)
   }
 
   /** retract based on Schema attributes 
     */
-  def retract[T, DD <: AnyRef, Card <: Cardinality, A](id: T)(prop: (Attribute[DD, Card], A))
-    (implicit ev: AsPermanentEntityId[T], attrC: Attribute2PartialAddEntityWriter[DD, Card, A]): RetractFact = {
-    val entityWriter = attrC.convert(prop._1)
-    val partial = entityWriter.write(prop._2)
-    val (kw: Keyword, value: AnyRef) = partial.props.head
-    new RetractFact(ev.conv(id), kw, value)
+  def retract[T, DD <: AnyRef, Card <: Cardinality, A](id: T)(attrVal: (Attribute[DD, Card], A))
+    (implicit ev1: AsPermanentEntityId[T], ev2: Attribute2FactWriter[DD, Card, A]): RetractFact = {
+    val (kw: Keyword, value: AnyRef) = ev2.convert(attrVal)
+    new RetractFact(ev1.conv(id), kw, value)
   }
 
 }

--- a/integration/src/it/scala/datomisca/PersonSampleData.scala
+++ b/integration/src/it/scala/datomisca/PersonSampleData.scala
@@ -66,7 +66,7 @@ object PersonSampleData extends SampleData {
       += (idAttr -> toto.id)
       += (nameAttr -> toto.name)
       += (ageAttr  -> toto.age)
-      += (moodAttr -> toto.moods)
+      ++= (moodAttr -> toto.moods)
   ) withId DId(Partition.USER)
 
   val tutu = new {
@@ -79,7 +79,7 @@ object PersonSampleData extends SampleData {
     SchemaEntity.newBuilder
       += (nameAttr -> tutu.name)
       += (ageAttr  -> tutu.age)
-      += (moodAttr -> tutu.moods)
+      ++= (moodAttr -> tutu.moods)
   ) withId DId(Partition.USER)
 
   val tata = new {
@@ -92,7 +92,7 @@ object PersonSampleData extends SampleData {
     SchemaEntity.newBuilder
       += (nameAttr -> tata.name)
       += (ageAttr  -> tata.age)
-      += (moodAttr -> tata.moods)
+      ++= (moodAttr -> tata.moods)
   ) withId DId(Partition.USER)
 
   override val txData = Seq(

--- a/integration/src/it/scala/datomisca/SchemaFactSchemaEntitySpec.scala
+++ b/integration/src/it/scala/datomisca/SchemaFactSchemaEntitySpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2012 Pellucid and Zenexity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package datomisca
+
+import scala.language.reflectiveCalls
+
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+class SchemaFactSchemaEntitySpec
+  extends FlatSpec
+     with Matchers
+     with OptionValues
+     with ScalaFutures
+     with DatomicFixture
+{
+
+  "SchemaFact" should "add a new value fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        SchemaFact.add(totoId)(PersonSampleData.Schema.ageAttr -> 31L)
+      )
+    ) { txReport =>
+      txReport.dbBefore.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (PersonSampleData.toto.age)
+      txReport.dbAfter.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (31L)
+    }
+  }
+
+
+  it should "add a new reference fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "tutu").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        SchemaFact.add(tutuId)(PersonSampleData.Schema.moodAttr -> PersonSampleData.Schema.angryMood)
+      )
+    ) { txReport =>
+      txReport.dbBefore.entity(tutuId).read[Set[Keyword]](PersonSampleData.Schema.moodAttr) should not contain (PersonSampleData.Schema.angryMood.ident)
+      txReport.dbAfter.entity(tutuId).read[Set[Keyword]](PersonSampleData.Schema.moodAttr) should contain (PersonSampleData.Schema.angryMood.ident)
+    }
+  }
+
+
+  it should "retract a value fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        SchemaFact.retract(totoId)(PersonSampleData.Schema.ageAttr -> PersonSampleData.toto.age)
+      )
+    ) { txReport =>
+      txReport.dbBefore.entity(totoId).keySet should contain (PersonSampleData.Schema.ageAttr.toString)
+      txReport.dbAfter.entity(totoId).keySet should not contain (PersonSampleData.Schema.ageAttr.toString)
+    }
+  }
+
+
+  it should "retract a reference fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "tutu").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        SchemaFact.retract(tutuId)(PersonSampleData.Schema.moodAttr -> PersonSampleData.Schema.stressedMood)
+      )
+    ) { txReport =>
+      txReport.dbBefore.entity(tutuId).read[Set[Keyword]](PersonSampleData.Schema.moodAttr) should contain (PersonSampleData.Schema.stressedMood.ident)
+      txReport.dbAfter.entity(tutuId).read[Set[Keyword]](PersonSampleData.Schema.moodAttr) should not contain (PersonSampleData.Schema.stressedMood.ident)
+    }
+  }
+
+
+
+  "SchemaEntity" should "add a new fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        (SchemaEntity.newBuilder += (PersonSampleData.Schema.ageAttr -> 31L)) withId totoId
+      )
+    ) { txReport =>
+      txReport.dbBefore.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (PersonSampleData.toto.age)
+      txReport.dbAfter.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (31L)
+    }
+  }
+
+
+  it should "add a new value fact (with a Some of Option)" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        (SchemaEntity.newBuilder +?= (PersonSampleData.Schema.ageAttr -> Some(31L))) withId totoId
+      )
+    ) { txReport =>
+      txReport.dbBefore.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (PersonSampleData.toto.age)
+      txReport.dbAfter.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (31L)
+    }
+  }
+
+
+  it should "add multiple facts" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "tutu").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        (SchemaEntity.newBuilder
+          ++= (PersonSampleData.Schema.moodAttr -> Set(PersonSampleData.Schema.angryMood, PersonSampleData.Schema.excitedMood))
+        ) withId tutuId
+      )
+    ) { txReport =>
+      txReport.dbBefore
+              .entity(tutuId)
+              .read[Set[Keyword]](PersonSampleData.Schema.moodAttr) should contain only (
+        PersonSampleData.Schema.sadMood.ident,
+        PersonSampleData.Schema.stressedMood.ident
+      )
+
+      txReport.dbAfter
+              .entity(tutuId)
+              .read[Set[Keyword]](PersonSampleData.Schema.moodAttr) should contain allOf (
+        PersonSampleData.Schema.sadMood.ident,
+        PersonSampleData.Schema.stressedMood.ident,
+        PersonSampleData.Schema.angryMood.ident,
+        PersonSampleData.Schema.excitedMood.ident
+      )
+    }
+  }
+
+
+  it should "add a from a partial entity" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+
+    whenReady(
+      Datomic.transact(
+        (SchemaEntity.newBuilder
+          ++= (SchemaEntity.newBuilder
+                 += (PersonSampleData.Schema.ageAttr -> 31L)
+              ).partial()
+        ) withId totoId
+      )
+    ) { txReport =>
+      txReport.dbBefore.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (PersonSampleData.toto.age)
+      txReport.dbAfter.entity(totoId).apply(PersonSampleData.Schema.ageAttr) should be (31L)
+    }
+  }
+
+}

--- a/integration/src/it/scala/datomisca/ToAndFromDatomicSpec.scala
+++ b/integration/src/it/scala/datomisca/ToAndFromDatomicSpec.scala
@@ -123,10 +123,10 @@ class ToFromDatomicSpec extends FlatSpec with Matchers {
     SchemaFact.add(id)(attrref -> 1L)
     SchemaFact.add(id)(attrref -> Datomic.KW(":my-kw"))
 
-    SchemaFact.add(id)(attrrefMany -> Set(DId(1L)))
-    SchemaFact.add(id)(attrrefMany -> Seq(DId(Partition.USER)))
-    SchemaFact.add(id)(attrrefMany -> List(1L))
-    SchemaFact.add(id)(attrrefMany -> Iterable(Datomic.KW(":my-kw")))
+    ( SchemaEntity.newBuilder ++= (attrrefMany -> Set(DId(1L))) ) withId (id)
+    ( SchemaEntity.newBuilder ++= (attrrefMany -> Seq(DId(Partition.USER))) ) withId (id)
+    ( SchemaEntity.newBuilder ++= (attrrefMany -> List(1L)) ) withId (id)
+    ( SchemaEntity.newBuilder ++= (attrrefMany -> Iterable(Datomic.KW(":my-kw"))) ) withId (id)
 
     SchemaFact.add(id)(attrrefMany -> DId(1L))
     SchemaFact.add(id)(attrrefMany -> DId(Partition.USER))
@@ -135,15 +135,15 @@ class ToFromDatomicSpec extends FlatSpec with Matchers {
 
     val addfact = Fact.add(id)(attrstring.ident -> "str")
     SchemaFact.add(id)(attrref -> addfact)
-    SchemaFact.add(id)(attrrefMany -> Set(addfact))
+    ( SchemaEntity.newBuilder ++= (attrrefMany -> Set(addfact)) ) withId (id)
 
     val retractfact = Fact.retract(id)(attrstring.ident -> "str")
     SchemaFact.add(id)(attrref -> retractfact)
-    SchemaFact.add(id)(attrrefMany -> Set(retractfact))
+    ( SchemaEntity.newBuilder ++= (attrrefMany -> Set(retractfact)) ) withId (id)
 
     val identEntity = AddIdent(Datomic.KW(":my-kw"))
     SchemaFact.add(id)(attrref -> identEntity)
-    SchemaFact.add(id)(attrrefMany -> Set(identEntity))
+    ( SchemaEntity.newBuilder ++= (attrrefMany -> Set(identEntity)) ) withId (id)
 
   }
 


### PR DESCRIPTION
The following should be invalid in Datomic

``` clojure
[:db/add id :attr [a b c]]
```

However, this was previously permitted. This is now eliminated.

The typeclass `Attribute2FactWriter` is introduced to implement this, and it also has the bonus of being a more efficient implementation over `Attribute2PartialAddEntityWriter`.

Also, expand the methods on SchemaEntityBuilder:

``` scala
+= (attr, val)
+?= (attr, optVal)
++= (manyAttr, coll)
++= partialEntity
```
