### PR TITLE
fix bad interaction of null with value classes

### DIFF
--- a/core/src/main/scala/datomisca/DId.scala
+++ b/core/src/main/scala/datomisca/DId.scala
@@ -45,6 +45,28 @@ final class TempId(val underlying: datomic.db.DbId) extends AnyVal with DId {
 final class LookupRef(val underlying: java.util.List[_]) extends AnyVal with DId {
   def toDatomicId = underlying
   override def toString = underlying.toString
+
+  /** Returns the referenced entity, or none if the
+    * lookup ref does not resolve.
+    */
+  def entity(implicit db: Database): Option[Entity] = {
+    val e = db.underlying.entity(this.underlying)
+    if (e ne null)
+      Some(new Entity(e))
+    else
+      None
+  }
+
+  /** Returns the referenced entity id, or none if the
+    * lookup ref does not resolve.
+    */
+  def entid(implicit db: Database): Option[Long] = {
+    val l = db.underlying.entid(this.underlying).asInstanceOf[java.lang.Long]
+    if (l ne null)
+      Some(l.asInstanceOf[Long])
+    else
+      None
+  }
 }
 
 object LookupRef {

--- a/core/src/main/scala/datomisca/Database.scala
+++ b/core/src/main/scala/datomisca/Database.scala
@@ -30,8 +30,13 @@ class Database(val underlying: datomic.Database) extends AnyVal {
     *     an entity id.
     * @return an entity.
     */
-  def entity[T](id: T)(implicit ev: AsPermanentEntityId[T]): Entity =
-    new Entity(underlying.entity(ev.conv(id)))
+  def entity[T](id: T)(implicit ev: AsPermanentEntityId[T]): Entity = {
+    val e = underlying.entity(ev.conv(id))
+    if (e ne null)
+      new Entity(e)
+    else
+      throw new UnresolvedLookupRefException(ev.conv(id))
+  }
 
   /** Returns the entity for the given keyword.
     *
@@ -73,8 +78,13 @@ class Database(val underlying: datomic.Database) extends AnyVal {
     *     an entity id.
     * @return the entity id passed.
     */
-  def entid[T](id: T)(implicit ev: AsPermanentEntityId[T]): Long =
-    underlying.entid(ev.conv(id)).asInstanceOf[Long]
+  def entid[T](id: T)(implicit ev: AsPermanentEntityId[T]): Long = {
+    val l = underlying.entid(ev.conv(id)).asInstanceOf[java.lang.Long]
+    if (l ne null)
+      l.asInstanceOf[Long]
+    else
+      throw new UnresolvedLookupRefException(ev.conv(id))
+  }
 
   /** Returns the entity id associated with a symbolic keyword
     *

--- a/core/src/main/scala/datomisca/exceptions.scala
+++ b/core/src/main/scala/datomisca/exceptions.scala
@@ -28,6 +28,9 @@ class DatomiscaException(message: String, cause: Throwable) extends RuntimeExcep
 class TempidNotResolved(id: DId)
   extends DatomiscaException(s"entity not found with id($id)")
 
+class UnresolvedLookupRefException(ref: AnyRef)
+  extends DatomiscaException(s"could not resolve lookup ref $ref")
+
 class UnsupportedDatomicTypeException(cls: Class[_])
   extends DatomiscaException(s"Datomic returned un supported ${cls.getName}")
 


### PR DESCRIPTION
db.entity and db.entid both return null if given a lookup ref that does not resolve.

Constructing the Entity value class from the return value of a method that can return null causes problems. And also, `null.asInstanceOf[Long] == 0`. This fix tests for nulls and throws exceptions.

To be able to test for lookup ref resolution without needing to trap exceptions, helper methods are added to the lookup ref class that return Option.
