### PR TITLE
Add overload to construct raw lookup refs

### DIFF
--- a/core/src/main/scala/datomisca/DId.scala
+++ b/core/src/main/scala/datomisca/DId.scala
@@ -70,6 +70,9 @@ final class LookupRef(val underlying: java.util.List[_]) extends AnyVal with DId
 }
 
 object LookupRef {
+  def apply[T](keyword: Keyword, value: T)(implicit toDatomicCast: ToDatomicCast[T]) =
+    new LookupRef(Util.list(keyword, toDatomicCast.to(value)))
+
   def apply[DD <: AnyRef, T](attr: Attribute[DD, Cardinality.one.type], value: T)
                             (implicit toDatomic: ToDatomic[DD, T]) =
     new LookupRef(Util.list(attr.ident, toDatomic.to(value)))


### PR DESCRIPTION
Add a less type safe overload to `LookupRef.apply` to construct a lookup ref directly from a keyword and value. 
