### PR TITLE
Update features documentation to not use old APIs

### DIFF
--- a/doc/features.md
+++ b/doc/features.md
@@ -247,8 +247,8 @@ val e = (SchemaEntity.newBuilder
 
 // ERROR at compile-time (field "name" should be a string)
 val e = (SchemaEntity.newBuilder
-  += (PersonSchema.name  -> 123) +
-  += (PersonSchema.age   -> 45L) +
+  += (PersonSchema.name  -> 123)
+  += (PersonSchema.age   -> 45L)
   += (PersonSchema.birth -> birthDate)
 ) withId DId(Partition.USER)
 


### PR DESCRIPTION
`SchemaEntity.add` has been replaced by `SchemaEntity.newBuilder`. This
updates an old usage in the docs.
