### PR TITLE
Allow mappings to case classes with 22 instead of just 20.

### DIFF
--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -224,7 +224,7 @@ object Boilerplate {
         |
         |private[datomisca] trait InvokeTxFunctionGen {""" +
            instances + """
-          
+
         |}
         |""").stripMargin
   }
@@ -240,6 +240,7 @@ object Boilerplate {
       val typeList = ((1 to arity) map (n => "A"+n)) // A1 A2 ... An
       val typeListDec = typeList.init // A1 A2 ... An-1
       val typeParams = typeList.mkString("[", ", ", "]") // [A1, A2, ... An]
+      val typeParamsInc = ((1 to (arity+1)) map (n => "A"+n)).mkString("[", ", ", "]") // [A1, A2, ... An+1]
       val combParams = typeList.mkString("~") // A1~A2~... An
       val combDec = typeListDec.mkString("[", " ~ ", "]") // [A1 ~ A2 ~ ... An-1]
       val params = typeList.mkString("(", ", ", ")") // (A1, A2, ... An)
@@ -250,26 +251,26 @@ object Boilerplate {
       val valsWithTypes = ((1 to arity) map (n => "a"+n+": A"+n)).mkString("(", ", ", ")") // (a1: A1, a2: A2, ... an: A2)
       val valsWithIdx = ((1 to arity) map (n => "a._"+n)).mkString("(", ", ", ")") // (a._1, a._2, ... a._n)
 
-      ("""|
-          |  class Builder"""+arity+typeParams+"(m1: M"+combDec+", m2:M[A"+arity+"""]) {
-          |    def ~"""+typeParamInc+"(m3: M"+typeParamInc+") = new Builder"+(arity+1)+"""(combi(m1, m2), m3)
-          |    def and"""+typeParamInc+"(m3: M"+typeParamInc+""") = this.~(m3)
+      s"""|
+          |  class Builder${arity}${typeParams}(m1: M$combDec, m2:M[A$arity]) {
+          |    def ~${typeParamInc}(m3: M${typeParamInc}) = new Builder${arity+1}${typeParamsInc}(combi(m1, m2), m3)
+          |    def and${typeParamInc}(m3: M${typeParamInc}) = this.~(m3)
           |
-          |    def apply[B](f: """+params+""" => B)(implicit functor: Functor[M]): M[B] =
-          |      functor.fmap["""+combParams+", B](combi(m1, m2), { case "+combVals+" => f"+parenVals+""" })
+          |    def apply[B](f: ${params} => B)(implicit functor: Functor[M]): M[B] =
+          |      functor.fmap[${combParams}, B](combi(m1, m2), { case $combVals => f${parenVals} })
           |
-          |    def apply[B](f: B => """+params+""")(implicit functor: ContraFunctor[M]): M[B] =
-          |      functor.contramap["""+combParams+", B](combi(m1, m2), { (b: B) => f(b) match { case "+parenVals+" => "+genNesting(arity)+""" } })
+          |    def apply[B](f: B => ${params})(implicit functor: ContraFunctor[M]): M[B] =
+          |      functor.contramap[${combParams}, B](combi(m1, m2), { (b: B) => f(b) match { case $parenVals => ${genNesting(arity)} } })
           |
-          |    def tupled(implicit v: Variant[M]): M["""+params+"""] = (v: @unchecked) match {
-          |      case f: Functor[M] => apply("""+valsWithTypes+" => "+parenVals+""")(f)
-          |      case f: ContraFunctor[M] => apply((a: """+params+") => "+valsWithIdx+""")(f)
+          |    def tupled(implicit v: Variant[M]): M[${params}] = (v: @unchecked) match {
+          |      case f: Functor[M] => apply(${valsWithTypes} => ${parenVals})(f)
+          |      case f: ContraFunctor[M] => apply((a: ${params}) => ${valsWithIdx})(f)
           |    }
           |  }
-          |""").stripMargin
+          |""".stripMargin
     }
 
-    val size = 20 // long compile for 21 and out of mem for 22
+    val size = 22
 
     val instances = ((2 until size) map genInstance).mkString
 


### PR DESCRIPTION
I was able to figure out the problem that was preventing builders from supporting 22 fields. It turns out it was the omission of some type params that were supposed to be there. I'm honestly not entirely sure how it compiled before, because those type parameters should definitely be there. 

I also changed the output to use string interpolation for clarity, which maybe I shouldn't have done at this moment, since it made the diff a little harder to read. But the only part I changed was  

this: `new Builder${arity+1}(combi(m1, m2), m3)`

to this `new Builder${arity+1}${typeParamsInc}(combi(m1, m2), m3)` 

On my SBT, the whole thing compiles in just a few seconds, and there are no memory errors. I used a heap size of 1G. Have not tried other sizes.  
