### PR TITLE
add support for Database.invoke (fixes #121)

### DIFF
--- a/core/src/main/scala/datomisca/Database.scala
+++ b/core/src/main/scala/datomisca/Database.scala
@@ -345,9 +345,33 @@ class Database(val underlying: datomic.Database) extends AnyVal {
     */
   def sinceT: Option[Long] = Option { underlying.sinceT }
 
-  // TODO
-  // indexRange
-  // invoke
+
+  /** Look up the database function of the ident entity `ident`, and invoke the function with `args`.
+    *
+    * The function value is stored as the value of the `:db/fn` attribute of the resolved entity.
+    *
+    * Note that no casts or conversions are applied to the arguments or the return value.
+    *
+    * @param  ident  the entity ident.
+    * @param  args  the raw arguments to pass to the function.
+    * @return the result of the function invocation.
+    */
+  def invoke(ident: Keyword, args: AnyRef*): AnyRef =
+    underlying.invoke(entid(ident), args:_*)
+
+
+  /** Look up the database function of the entity `id`, and invoke the function with `args`.
+    *
+    * The function value is stored as the value of the `:db/fn` attribute of the resolved entity.
+    *
+    * Note that no casts or conversions are applied to the arguments or the return value.
+    *
+    * @param  id  the entity id.
+    * @param  args  the raw arguments to pass to the function.
+    * @return the result of the function invocation.
+    */
+  def invoke[T](id: T, args: AnyRef*)(implicit ev: AsPermanentEntityId[T]): AnyRef =
+    underlying.invoke(ev.conv(id), args:_*)
 
 }
 

--- a/integration/src/it/scala/datomisca/InvokeDbFnSpec.scala
+++ b/integration/src/it/scala/datomisca/InvokeDbFnSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 Pellucid and Zenexity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package datomisca
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+class InvokeDbFnSpec
+  extends FlatSpec
+     with Matchers
+     with DatomicFixture
+     with AwaitHelper
+{
+
+  object DbFnSchema {
+
+    val fn = new Namespace("fn")
+
+    val myFn =
+      AddDbFunction(fn / "my-fn")("h", "t")(lang = "clojure", partition = Partition.USER, imports = "", requires = "[[clojure.string :as str]]") {"""
+        (str/split (str h " " t) #"\s")
+      """}
+
+    val schema = Seq(myFn)
+  }
+
+  "InvokeDbFn" should "invoke db fn in peer" in withDatomicDB { implicit conn =>
+    await {
+      Datomic.transact(DbFnSchema.schema)
+    }
+
+    val db = conn.database
+
+    val res = db.invoke(DbFnSchema.myFn.ident, "The", "Quick Brown Fox")
+
+    res.toString should equal ("""["The" "Quick" "Brown" "Fox"]""")
+  }
+}


### PR DESCRIPTION
add invoke method with two overloads, one for an entity ident and one for an entity id
