### PR TITLE
support Entity.db method (fixes #122)

### DIFF
--- a/core/src/main/scala/datomisca/Entity.scala
+++ b/core/src/main/scala/datomisca/Entity.scala
@@ -21,6 +21,10 @@ import scala.concurrent.blocking
 
 class Entity(val entity: datomic.Entity) extends AnyVal {
 
+  /** the database value that is the basis for this entity
+    */
+  def database: Database = new Database(entity.db)
+
   def id: Long = as[Long](Namespace.DB / "id")
 
   def touch() = {


### PR DESCRIPTION
add in method that returns the database value that is the basis for an entity
http://docs.datomic.com/javadoc/datomic/Entity.html#db()
