### PR TITLE
ensure that all impure methods have () (fixes #123)

### DIFF
--- a/core/src/main/scala/datomisca/Connection.scala
+++ b/core/src/main/scala/datomisca/Connection.scala
@@ -27,7 +27,13 @@ import datomic.ListenableFuture
 
 class Connection(val connection: datomic.Connection) extends AnyVal {
 
-  def database: Database = new Database(connection.db())
+  /** Retrieves a value of the database for reading.
+    *
+    * Does not communicate with the transactor, nor block.
+    *
+    * @return the current value of the database.
+    */
+  def database(): Database = new Database(connection.db())
 
   /**
     * Used to coordinate with other peers.
@@ -100,11 +106,11 @@ class Connection(val connection: datomic.Connection) extends AnyVal {
     }
   }
 
-  def txReportQueue: TxReportQueue = new TxReportQueue(connection.txReportQueue)
+  def txReportQueue(): TxReportQueue = new TxReportQueue(connection.txReportQueue)
 
-  def removeTxReportQueue: Unit = connection.removeTxReportQueue
+  def removeTxReportQueue(): Unit = connection.removeTxReportQueue
 
-  def requestIndex: Boolean = connection.requestIndex
+  def requestIndex(): Boolean = connection.requestIndex
 
   def gcStorage(olderThan: java.util.Date): Unit = connection.gcStorage(olderThan)
 

--- a/core/src/main/scala/datomisca/PeerOps.scala
+++ b/core/src/main/scala/datomisca/PeerOps.scala
@@ -54,7 +54,7 @@ private[datomisca] trait PeerOps {
     * database.transact(...)
     * }}}
     */
-  def database(implicit conn: Connection): Database = conn.database
+  def database()(implicit conn: Connection): Database = conn.database()
 
   /** Creates a new database using uri
     * @param uri the Uri of the DB

--- a/core/src/main/scala/datomisca/schemaManagement.scala
+++ b/core/src/main/scala/datomisca/schemaManagement.scala
@@ -42,7 +42,7 @@ object SchemaManager {
 
   private[datomisca] def ensureSchemaTag(schemaTag: Keyword)(implicit conn: Connection, ec: ExecutionContext): Future[Boolean] =
     Future {
-      hasAttribute(schemaTag)(conn.database)
+      hasAttribute(schemaTag)(conn.database())
     } flatMap {
       case true  => Future.successful(false)
       case false =>
@@ -64,7 +64,7 @@ object SchemaManager {
       ensureSchemas(schemaTag, schemaMap, requires: _*) flatMap { dependentsChanged =>
         if (txDatas.isEmpty) {
           throw new DatomiscaException(s"No schema data provided for schema ${schemaName}")
-        } else if (hasSchema(schemaTag, schemaName)(conn.database)) {
+        } else if (hasSchema(schemaTag, schemaName)(conn.database())) {
           Future.successful(dependentsChanged)
         } else {
           Future.traverse(txDatas) { txData =>

--- a/integration/src/it/scala/datomisca/AccountsSampleSpec.scala
+++ b/integration/src/it/scala/datomisca/AccountsSampleSpec.scala
@@ -173,11 +173,11 @@ class AccountsSampleSpec
     }
 
     val issuerId =
-      Datomic.q(findAccountByName, conn.database, "Issuer").head.asInstanceOf[Long]
+      Datomic.q(findAccountByName, conn.database(), "Issuer").head.asInstanceOf[Long]
     val bobId =
-      Datomic.q(findAccountByName, conn.database, "Bob").head.asInstanceOf[Long]
+      Datomic.q(findAccountByName, conn.database(), "Bob").head.asInstanceOf[Long]
     val aliceId =
-      Datomic.q(findAccountByName, conn.database, "Alice").head.asInstanceOf[Long]
+      Datomic.q(findAccountByName, conn.database(), "Alice").head.asInstanceOf[Long]
 
     await {
       Datomic.transact(transfer(issuerId, aliceId, BigDecimal(77), "Issuance to Alice"))
@@ -189,15 +189,15 @@ class AccountsSampleSpec
       Datomic.transact(transfer(aliceId, bobId, BigDecimal(7), "Dinner"))
     }
 
-    Datomic.q(queryAccounts, conn.database) should have size (3)
+    Datomic.q(queryAccounts, conn.database()) should have size (3)
 
-    Datomic.q(queryAllTransactions, conn.database) should have size (3)
+    Datomic.q(queryAllTransactions, conn.database()) should have size (3)
 
-    Datomic.q(queryAccountTransactions, conn.database, rulesParty, issuerId) should have size (2)
+    Datomic.q(queryAccountTransactions, conn.database(), rulesParty, issuerId) should have size (2)
 
-    Datomic.q(queryAccountTransactions, conn.database, rulesParty, bobId) should have size (2)
+    Datomic.q(queryAccountTransactions, conn.database(), rulesParty, bobId) should have size (2)
 
-    Datomic.q(queryAccountTransactions, conn.database, rulesParty, aliceId) should have size (2)
+    Datomic.q(queryAccountTransactions, conn.database(), rulesParty, aliceId) should have size (2)
 
     an [IllegalStateException] should be thrownBy {
       await {

--- a/integration/src/it/scala/datomisca/AggregatesSpec.scala
+++ b/integration/src/it/scala/datomisca/AggregatesSpec.scala
@@ -104,7 +104,7 @@ class AggregatesSpec
   """)
 
   "Aggregates examples" should "run to completion" in withSampleDatomicDB(PlutoSampleData) { conn =>
-    val db = conn.database
+    val db = conn.database()
 
     Datomic.q(countObjects, db).headOption.value should equal (17)
 

--- a/integration/src/it/scala/datomisca/BindingSpec.scala
+++ b/integration/src/it/scala/datomisca/BindingSpec.scala
@@ -96,9 +96,9 @@ class BindingSpec
          :where [?e ?attrId]]
       """)
 
-    val ds = conn.database.datoms(Database.AEVT, Attribute.doc)
+    val ds = conn.database().datoms(Database.AEVT, Attribute.doc)
 
-    val res = Datomic.q(query, ds, conn.database.entid(Attribute.doc))
+    val res = Datomic.q(query, ds, conn.database().entid(Attribute.doc))
 
     res should contain (0)
   }

--- a/integration/src/it/scala/datomisca/ComponentAttributesSpec.scala
+++ b/integration/src/it/scala/datomisca/ComponentAttributesSpec.scala
@@ -33,7 +33,7 @@ class ComponentAttributesSpec
   "Component attributes example" should "run to completion" in withSampleDatomicDB(SocialNewsSampleData) { implicit conn =>
 
     whenReady(Datomic.transact(SocialNewsSampleData.storyWithComments)) { _ =>
-      whenReady(Datomic.transact(Entity.retract(conn.database.entid(Datomic.KW(":storyWithComments"))))) { txReport =>
+      whenReady(Datomic.transact(Entity.retract(conn.database().entid(Datomic.KW(":storyWithComments"))))) { txReport =>
         val builder = Set.newBuilder[Long]
         for (datom <- txReport.txData)
           if (!datom.added)

--- a/integration/src/it/scala/datomisca/DatabaseFilteringSpec.scala
+++ b/integration/src/it/scala/datomisca/DatabaseFilteringSpec.scala
@@ -41,7 +41,7 @@ class DatabaseFilteringSpec
       Future.traverse(SocialNewsSampleData.txDatas)(conn.transact)
     }
 
-    val db = conn.database
+    val db = conn.database()
 
     Datomic.q(countStories, db).head should equal (4)
 

--- a/integration/src/it/scala/datomisca/ExcisionSpec.scala
+++ b/integration/src/it/scala/datomisca/ExcisionSpec.scala
@@ -34,7 +34,7 @@ class ExcisionSpec
 
   "Datomic’s excision" can "excise specific entities" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
 
-    val dbBefore = conn.database
+    val dbBefore = conn.database()
 
     val e = Datomic.q(PersonSampleData.queryPersonIdByName, dbBefore, PersonSampleData.toto.name).head.asInstanceOf[Long]
 
@@ -56,7 +56,7 @@ class ExcisionSpec
 
   it can "excise entities by lookup ref" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
 
-    val dbBefore = conn.database
+    val dbBefore = conn.database()
 
     val e = LookupRef(PersonSampleData.Schema.idAttr, PersonSampleData.toto.id)
 
@@ -78,7 +78,7 @@ class ExcisionSpec
 
   it can "excise specific attributes of an entity" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
 
-    val dbBefore = conn.database
+    val dbBefore = conn.database()
 
     val e = Datomic.q(PersonSampleData.queryPersonIdByName, dbBefore, PersonSampleData.toto.name).head.asInstanceOf[Long]
 
@@ -129,7 +129,7 @@ class ExcisionSpec
   it can "excise values of an attribute before a basis T" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
 
     val excisionId = DId(Partition.USER)
-    val beforeT = conn.database.basisT
+    val beforeT = conn.database().basisT
     whenReady(
       Datomic.transact(Excise.attribute(PersonSampleData.Schema.ageAttr.ident, excisionId, beforeT))
     ) { txReport =>

--- a/integration/src/it/scala/datomisca/MovieGraph2SampleSpec.scala
+++ b/integration/src/it/scala/datomisca/MovieGraph2SampleSpec.scala
@@ -213,7 +213,7 @@ class MovieGraph2SampleSpec
       Datomic.transact(MovieGraph2Data.txData)
     }
 
-    val db = conn.database
+    val db = conn.database()
 
     Datomic.q(queryFindMovieByTitle, db, "The Matrix") should have size (1)
 

--- a/integration/src/it/scala/datomisca/MovieGraphSampleSpec.scala
+++ b/integration/src/it/scala/datomisca/MovieGraphSampleSpec.scala
@@ -201,7 +201,7 @@ class MovieGraphSampleSpec
       }
     }
 
-    val db = conn.database
+    val db = conn.database()
 
     Datomic.q(queryFindMovieByTitle, db, "The Matrix") should have size (1)
 

--- a/integration/src/it/scala/datomisca/SchemaFactSchemaEntitySpec.scala
+++ b/integration/src/it/scala/datomisca/SchemaFactSchemaEntitySpec.scala
@@ -33,7 +33,7 @@ class SchemaFactSchemaEntitySpec
 {
 
   "SchemaFact" should "add a new value fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "toto").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(
@@ -47,7 +47,7 @@ class SchemaFactSchemaEntitySpec
 
 
   it should "add a new reference fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "tutu").head.asInstanceOf[Long]
+    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "tutu").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(
@@ -61,7 +61,7 @@ class SchemaFactSchemaEntitySpec
 
 
   it should "retract a value fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "toto").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(
@@ -75,7 +75,7 @@ class SchemaFactSchemaEntitySpec
 
 
   it should "retract a reference fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "tutu").head.asInstanceOf[Long]
+    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "tutu").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(
@@ -90,7 +90,7 @@ class SchemaFactSchemaEntitySpec
 
 
   "SchemaEntity" should "add a new fact" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "toto").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(
@@ -104,7 +104,7 @@ class SchemaFactSchemaEntitySpec
 
 
   it should "add a new value fact (with a Some of Option)" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "toto").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(
@@ -118,7 +118,7 @@ class SchemaFactSchemaEntitySpec
 
 
   it should "add multiple facts" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "tutu").head.asInstanceOf[Long]
+    val tutuId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "tutu").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(
@@ -147,7 +147,7 @@ class SchemaFactSchemaEntitySpec
 
 
   it should "add a from a partial entity" in withSampleDatomicDB(PersonSampleData) { implicit conn =>
-    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database, "toto").head.asInstanceOf[Long]
+    val totoId = Datomic.q(PersonSampleData.queryPersonIdByName, conn.database(), "toto").head.asInstanceOf[Long]
 
     whenReady(
       Datomic.transact(

--- a/integration/src/it/scala/datomisca/SchemaManagerSpec.scala
+++ b/integration/src/it/scala/datomisca/SchemaManagerSpec.scala
@@ -70,7 +70,7 @@ class SchemaManagerSpec
 
     // Install schema A into an empty db
     whenReady(SchemaManager.installSchema(schemaTag, schemaMap, SchemaA.name)) { changed =>
-      implicit val db = conn.database
+      implicit val db = conn.database()
 
       changed should be (true)
 
@@ -88,7 +88,7 @@ class SchemaManagerSpec
 
     // install schema C
     whenReady(SchemaManager.installSchema(schemaTag, schemaMap, SchemaC.name)) { changed =>
-      implicit val db = conn.database
+      implicit val db = conn.database()
 
       changed should be (true)
 
@@ -113,7 +113,7 @@ class SchemaManagerSpec
 
     // reïnstall schema C (which should be an update of schema A)
     whenReady(SchemaManager.installSchema(schemaTag, schemaMap, SchemaC.name)) { changed =>
-      implicit val db = conn.database
+      implicit val db = conn.database()
 
       changed should be (true)
 


### PR DESCRIPTION
methods such as `Connection.database` are not referentially transparent
