### PR TITLE
add constant for db.alter namespace

### DIFF
--- a/core/src/main/scala/datomisca/namespace.scala
+++ b/core/src/main/scala/datomisca/namespace.scala
@@ -32,5 +32,6 @@ object Namespace {
     val UNIQUE = Namespace("db.unique")
     val FN = Namespace("db.fn")
     val EXCISE = Namespace("db.excise")
+    val ALTER = Namespace("db.alter")
   } 
 }


### PR DESCRIPTION
add in a namespace constant for the reserved `db.alter` namespace for schema alteration idents
