### PR TITLE
add readWithDefault for rich entities and rich attributes

### DIFF
--- a/core/src/main/scala/datomisca/package.scala
+++ b/core/src/main/scala/datomisca/package.scala
@@ -119,7 +119,7 @@ package object datomisca {
       * @return the value associated with `attr` in this entity,
       *     otherwise the result of the `default` computation..
       */
-    def readWithDefault[DD <: AnyRef, Card <: Cardinality, T]
+    def readOrElse[DD <: AnyRef, Card <: Cardinality, T]
                (attr: Attribute[DD, Card], default: => T)
                (implicit attrC: Attribute2EntityReaderCast[DD, Card, T])
                : T = {
@@ -259,7 +259,7 @@ package object datomisca {
       * @return an entity reader that reads entities with this attribute.
       * @see [[EntityReader]]
       */
-    def readWithDefault[A](default: => A)(implicit ev: Attribute2EntityReaderCast[DD, Card, A]): EntityReader[A] =
+    def readOrElse[A](default: => A)(implicit ev: Attribute2EntityReaderCast[DD, Card, A]): EntityReader[A] =
       EntityReader[A] { e: Entity =>
         if (e.contains(attribute.ident))
           ev.convert(attribute).read(e)

--- a/integration/src/it/scala/datomisca/RichAttributeSpec.scala
+++ b/integration/src/it/scala/datomisca/RichAttributeSpec.scala
@@ -45,9 +45,9 @@ class RichAttributeSpec
 
     Schema.ageAttr.readOpt[Long].read(entity).value should be (PersonSampleData.tata.age)
 
-    Schema.nameAttr.readWithDefault("foo").read(entity) should equal (PersonSampleData.tata.name)
+    Schema.nameAttr.readOrElse("foo").read(entity) should equal (PersonSampleData.tata.name)
 
-    Schema.idAttr.readWithDefault(0).read(entity) should equal (0)
+    Schema.idAttr.readOrElse(0).read(entity) should equal (0)
 
     Schema.ageAttr.read[Int].read(entity) should be (PersonSampleData.tata.age.toInt)
 

--- a/integration/src/it/scala/datomisca/RichEntitySpec.scala
+++ b/integration/src/it/scala/datomisca/RichEntitySpec.scala
@@ -62,9 +62,9 @@ class RichEntitySpec
 
     entity.readOpt[Long](Schema.ageAttr).value should be (PersonSampleData.tata.age)
 
-    entity.readWithDefault(Schema.nameAttr, "foo") should equal (PersonSampleData.tata.name)
+    entity.readOrElse(Schema.nameAttr, "foo") should equal (PersonSampleData.tata.name)
 
-    entity.readWithDefault(Schema.idAttr, 0) should equal (0)
+    entity.readOrElse(Schema.idAttr, 0) should equal (0)
 
     entity.read[Int](Schema.ageAttr) should be (PersonSampleData.tata.age.toInt)
 


### PR DESCRIPTION
This is added as a convenience mechanism after feedback from @tixxit.

``` scala
val default: T = …
entity.readWithDefault(attr, default)
```

is provided as a convenience for

``` scala
entity.readOpt[T](attr).getOrElse(default)
```

and

``` scala
val r = attr.readWithDefault(default)
r.read(entity)
```

is provided as a convenience for

``` scala
val r = attr.readOpt[T].map(_.getOrElse(default))
r.read(entity)
```
