### PR TITLE
never catch all throwables, use NonFatal instead

### DIFF
--- a/core/src/main/scala/datomisca/Connection.scala
+++ b/core/src/main/scala/datomisca/Connection.scala
@@ -204,7 +204,7 @@ object Connection {
           } catch {
             case ex: java.util.concurrent.ExecutionException =>
               p.failure(ex.getCause)
-            case ex: Throwable =>
+            case NonFatal(ex) =>
               p.failure(ex)
           }
       },

--- a/core/src/main/scala/datomisca/entityMapper.scala
+++ b/core/src/main/scala/datomisca/entityMapper.scala
@@ -17,6 +17,7 @@
 package datomisca
 
 import scala.annotation.implicitNotFound
+import scala.util.control.NonFatal
 
 import functional._
 
@@ -40,7 +41,7 @@ trait EntityReader[A] extends EntityMapper[A] {
     try {
       self.read(e)
     } catch {
-      case ex: Throwable => other.read(e)
+      case NonFatal(ex) => other.read(e)
     }
   }
 


### PR DESCRIPTION
fix catch expressions that trap all throwables. scala.util.control.NonFatal should be used instead.