### PR TITLE
Reverse on :db/isComponent attributes has a special case for reading.

### DIFF
--- a/core/src/main/scala/datomisca/Attribute.scala
+++ b/core/src/main/scala/datomisca/Attribute.scala
@@ -62,6 +62,16 @@ final case class Attribute[DD, Card <: Cardinality](
       cardinality = Cardinality.many
     )
 
+  /** Construct the reverse attribute, if this is a component reference attribute */
+  def reverseComponent(implicit ev: =:=[DatomicRef.type, DD]): Attribute[DatomicRef.type, Cardinality.one.type] = {
+    require(isComponent.getOrElse(false))
+    copy(
+      ident       = clojure.lang.Keyword.intern(ident.getNamespace, "_" + ident.getName),
+      valueType   = SchemaType.ref,
+      cardinality = Cardinality.one
+    )
+  }
+
   // using partiton :db.part/db
   val id = DId(Partition.DB)
 


### PR DESCRIPTION
Fixes a 'bug' where RichEntity.read can not be used for reversed attributes that are components, due to an undocumented special case in datomic.Entity.get. Datomisca is expecting a collection but receives a single entity response, and throws an exception.
We've run in to this issue a few times, and had to drop down to using Entity.getAs.

Refer:
- https://groups.google.com/forum/#!searchin/datomic/reverse$20get/datomic/Eu7l__rA-xk/MWqTTECbJI0J
