### PR TITLE
Add ToDatomic conversion for Log

### DIFF
--- a/core/src/main/scala/datomisca/toAndFromDatomic.scala
+++ b/core/src/main/scala/datomisca/toAndFromDatomic.scala
@@ -257,6 +257,7 @@ trait ToDatomicImplicits {
   implicit val dbConv = ToDatomic[datomic.Database, Database](_.underlying)
   implicit val datomConv = ToDatomic[datomic.Datom, Datom](_.underlying)
   implicit val rulesConv = ToDatomic[clojure.lang.IPersistentCollection, QueryRules](_.edn)
+  implicit val logConv = ToDatomic[datomic.Log, Log](_.log)
 
 }
 


### PR DESCRIPTION
Conversion is needed so that a connection can be passed into a query.
Issue reported in https://groups.google.com/d/msg/datomic/CUHg449accw/79-NhP5qVqgJ